### PR TITLE
Persist extracted data in database

### DIFF
--- a/etl/package.json
+++ b/etl/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "doc": "jsdoc --verbose -c ./jsdoc.json",
     "extract": "node ./src/etl-runner.js",
+    "upload": "node ./src/upload.js",
     "test": "NODE_OPTIONS=--experimental-vm-modules pnpm jest",
     "test:watch": "pnpm run test -- --watch"
   },

--- a/etl/src/database.js
+++ b/etl/src/database.js
@@ -1,10 +1,6 @@
 import { initializeApp } from "firebase/app";
 import {getFirestore} from "firebase/firestore";
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
 
-// Your web app's Firebase configuration
-// For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
     apiKey: "AIzaSyBUkI5ks9lEFuqejngEBD4NY-DDRAWeef0",
     authDomain: "scrapy-1281d.firebaseapp.com",
@@ -15,7 +11,6 @@ const firebaseConfig = {
     measurementId: "G-MX1MMW28KP"
 };
 
-// Initialize Firebase
 const app = initializeApp(firebaseConfig);
 
-const database = getFirestore(app);
+export const database = getFirestore(app);

--- a/etl/src/database.js
+++ b/etl/src/database.js
@@ -13,4 +13,5 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 
+/** @type {Firestore} */
 export const database = getFirestore(app);

--- a/etl/src/etl-runner.js
+++ b/etl/src/etl-runner.js
@@ -1,14 +1,21 @@
 import {extractSchwinger, fetchSchwinger} from './extract.js';
 import {transformSchwinger} from "./transform.js";
-import {loadSchwingerToFile} from "./load.js";
+import {loadSchwingerToDatabase, loadSchwingerToFile} from "./load.js";
 import {createSearch} from "./search.js";
+import {database} from "./database.js";
+
+
+/** @type {LoadConfig} */
+const loadConfig = {
+    path: `./dist/data/${new Date().toISOString()}_schwinger.json`,
+}
 
 await extractSchwinger(
     createSearch('a', 'zz'),
     fetchSchwinger,
     transformSchwinger,
     loadSchwingerToFile,
-    {
-        path: `./dist/data/${new Date().toISOString()}_schwinger.json`,
-    }
+    loadConfig,
 );
+
+await loadSchwingerToDatabase(database, loadConfig);

--- a/etl/src/load.js
+++ b/etl/src/load.js
@@ -1,8 +1,28 @@
 import fs from "fs";
 import path from "path";
+import {writeBatch, doc} from "firebase/firestore";
 
+/**
+ * Loads the transformed Schwinger into a file.
+ *
+ * @typedef {Object} LoadConfig
+ * @property {string} path - The path to the file to store the Schwinger in
+ *
+ * @typedef {Object} LoadStats
+ * @property {boolean} success - Whether the loading was successful
+ * @property {string} location - The location of the file where the Schwinger are stored
+ * @property {number} totalNumberOfRecords - The number of records that are stored in the file after the current load
+ * @property {number} numberOfRecordsAdded - The number of records that were added to the file
+ *
+ * @typedef {Object} PartialLoadStats
+ * @property {boolean} success - Whether the loading was successful
+ * @property {number} numberOfRecords - The number of records that were added to the file
+ *
+ * @param {Schwinger[]} transformedSchwinger - An array of Schwinger to be stored in the file
+ * @param {LoadConfig} config - The configuration for storing the Schwinger
+ * @returns {{LoadStats}|{PartialLoadStats}} - The statistics of the load
+ */
 export function loadSchwingerToFile(transformedSchwinger, config) {
-
     if (!Array.isArray(transformedSchwinger)) {
         throw new Error('input must be an array');
     }
@@ -16,7 +36,7 @@ export function loadSchwingerToFile(transformedSchwinger, config) {
     const pathToStoreSchwingerFile = path.join(process.cwd(), config.path);
     const schwingerFileDir = path.dirname(pathToStoreSchwingerFile)
 
-    if (!fs.existsSync(schwingerFileDir)){
+    if (!fs.existsSync(schwingerFileDir)) {
         fs.mkdirSync(schwingerFileDir);
     }
 
@@ -51,4 +71,49 @@ export function loadSchwingerToFile(transformedSchwinger, config) {
         numberOfRecordsAdded: newData.length,
         totalNumberOfRecords: combinedData.length
     }
+}
+
+
+/**
+ * Loads the transformed Schwinger into the database.
+ *
+ * Uploads all Schwinger of the specified file to the database using batch writes.
+ * Since batch writes are limited to 500 operations, the Schwinger are split into chunks of 500.
+ *
+ *
+ * @param {Firestore} database
+ * @param {LoadConfig} config
+ *
+ */
+// TODO: check if this should be done with the server client lib: https://firebase.google.com/docs/firestore/client/libraries#server_client_libraries
+export async function loadSchwingerToDatabase(database, config) {
+    const pathToStoreSchwingerFile = path.join(process.cwd(), config.path);
+    if (!fs.existsSync(pathToStoreSchwingerFile)) {
+        throw new Error('Implementation defect: file to upload does not exist');
+    }
+
+    /** @type {Schwinger[]} */
+    const dataToBeUploaded = JSON.parse(fs.readFileSync(pathToStoreSchwingerFile, 'utf8'));
+    console.log(`Loaded ${dataToBeUploaded.length} Schwinger from the specified file`);
+
+    const chunkSize = 500;
+    /** @type {Schwinger[][]} */
+    const chunks = [];
+    for (let i = 0; i < dataToBeUploaded.length; i += chunkSize) {
+        chunks.push(dataToBeUploaded.slice(i, i + chunkSize));
+    }
+    console.log(`Split the Schwinger into ${chunks.length} chunks of ${chunkSize} Schwinger each`);
+
+    let chunkCounter = 1;
+    for (const chunk of chunks) {
+        const batch = writeBatch(database);
+        for (const schwinger of chunk) {
+            const schwingerRef = doc(database, "schwinger", String(schwinger.id));
+            batch.set(schwingerRef, schwinger);
+        }
+        await batch.commit();
+        console.log(`Uploaded chunk ${chunkCounter++} of ${chunks.length}`);
+    }
+
+    console.log(`Successfully uploaded ${dataToBeUploaded.length} Schwinger to the database`);
 }

--- a/etl/src/transform.js
+++ b/etl/src/transform.js
@@ -1,3 +1,24 @@
+/**
+ * Transforms the response from the API to an entity that can be loaded into the database.
+ *
+ * The response from the API looks like this:
+ *
+ * @typedef {Object} Suggestion
+ * @property {string} value - The name of the Schwinger in the form `<firstName> <lastName>`
+ * @property {Object} data
+ * @property {number} data._id - The ID of the Schwinger
+ *
+ * @typedef {Object} SchwingerResponse
+ * @property {Suggestion[]} suggestions
+ *
+ * @typedef {Object} Schwinger
+ * @property {string} id
+ * @property {string} firstName
+ * @property {string} lastName
+ *
+ * @param {SchwingerResponse} response
+ * @returns {Schwinger[]}
+ */
 export function transformSchwinger(response) {
     const transformedSchwinger = [];
     for (const suggestion of response.suggestions) {

--- a/etl/src/transform.js
+++ b/etl/src/transform.js
@@ -12,7 +12,7 @@
  * @property {Suggestion[]} suggestions
  *
  * @typedef {Object} Schwinger
- * @property {string} id
+ * @property {number} id
  * @property {string} firstName
  * @property {string} lastName
  *

--- a/etl/src/upload.js
+++ b/etl/src/upload.js
@@ -1,0 +1,10 @@
+import {loadSchwingerToDatabase} from "./load.js";
+import {database} from "./database.js";
+
+/** @type {LoadConfig} */
+const loadConfig = {
+    path: './dist/data/2023-07-20T13:17:37.244Z_schwinger.json',
+}
+
+await loadSchwingerToDatabase(database, loadConfig);
+


### PR DESCRIPTION
Implements a simple script to upload all extracted Schwinger to the database (Firestore) reusing the configuration for loading the extracted data into a file.